### PR TITLE
DELETE a red-flag record

### DIFF
--- a/resources/incident/create.js
+++ b/resources/incident/create.js
@@ -25,6 +25,9 @@ module.exports = (req, res) => {
   incident.push(newRecord);
   return res.status(200).send({
     status: 200,
-    newRecord
-  })
+    data: [{
+      id: newId,
+      message: "Created red-flag record"
+    }]
+  });
 }

--- a/resources/incident/delete.js
+++ b/resources/incident/delete.js
@@ -1,0 +1,23 @@
+const data = require("../../data.json");
+
+module.exports = (req, res) => {
+  const incidentId = req.params.incidentId * 1;
+  const incident = data.incident;
+  const findIncident = incident.find(e => e.id === incidentId);
+  if (!findIncident) {
+    return res.status(404).send({
+      status: 404,
+      error: "Record was not found"
+    });
+  }
+  const newId = incident.length + 1;
+  const index = incident.indexOf(incident);
+  incident.splice(index, 1);
+  res.status(200).send({
+    status: 200,
+    data: [{
+      id: newId,
+      message: "red-flag record has been deleted"
+    }]
+  })
+}

--- a/resources/incident/index.js
+++ b/resources/incident/index.js
@@ -6,5 +6,6 @@ router.use(express.json());
 router.get("/", require("./all"));
 router.get("/:incidentId", require("./single"));
 router.post("/", require("./create"));
+router.delete("/:incidentId", require("./delete"));
 
 module.exports = router;

--- a/resources/incident/single.js
+++ b/resources/incident/single.js
@@ -4,11 +4,10 @@ module.exports = (req, res) => {
   const incidentId = req.params.incidentId * 1;
   const incident = data.incident.find(e => e.id === incidentId);
   if (!incident) {
-    res.status(404).send({
+    return res.status(404).send({
       status: 404,
       error: "Record was not found"
     });
-    return;
   }
   res.status(200).json({
     status: 200,

--- a/test/test.js
+++ b/test/test.js
@@ -45,5 +45,14 @@ describe("Red-Flag API Tests", () => {
         .expect("Content-Type", /json/)
         .expect(200, done);
     })
-  })
+  });
+  describe("/DELETE a red-flag record", () => {
+    it("should delete a red-flag record", (done) => {
+      request(app)
+        .delete("/api/v1/incident/2")
+        .set("Accept", "application/json")
+        .expect("Content-Type", /json/)
+        .expect(200, done);
+    })
+  });
 });


### PR DESCRIPTION
The purpose of this PR is to pass the id of the red-flag that needs to be deleted as a parameter to the route /api/v1/incident/:incidentId.
This is achieved by using the DELETE method.